### PR TITLE
Publish base image for tiny

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -6,14 +6,11 @@ on:
     inputs:
       TAG:
         required: true
-      BUILD_BASE_IMAGE_TAG:
-        required: true
 
 env:
   BUILD_REPO: "paketobuildpacks/build"
   RUN_REPO: "paketobuildpacks/run"
   TAG: ${{ github.event.client_payload.tag }}
-  BUILD_BASE_IMAGE_TAG: ${{ github.event.client_payload.build_base_image_tag }}
 
 jobs:
   create-release:
@@ -31,13 +28,7 @@ jobs:
       run: |
         if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
           echo "TAG=${{ github.event.inputs.TAG }}" >> $GITHUB_ENV
-          echo "BUILD_BASE_IMAGE_TAG=${{ github.event.inputs.BUILD_BASE_IMAGE_TAG }}" >> $GITHUB_ENV
         fi
-
-    - name: Docker login
-      run: |
-        docker login -u ${{ secrets.PAKETO_BUILDPACKS_DOCKERHUB_USERNAME }} --password-stdin \
-          < <(echo "${{ secrets.PAKETO_BUILDPACKS_DOCKERHUB_PASSWORD }}")
 
     - name: Get Image Refs
       id: image-refs
@@ -45,7 +36,7 @@ jobs:
       run: |
         run_base_sha="$(skopeo inspect "docker://${RUN_REPO}:${TAG}-tiny" | jq .Digest -r)"
         run_cnb_sha="$(skopeo inspect "docker://${RUN_REPO}:${TAG}-tiny-cnb" | jq .Digest -r)"
-        build_base_sha="$(skopeo inspect "docker://${BUILD_REPO}:${{ env.BUILD_BASE_IMAGE_TAG }}" | jq .Digest -r)"
+        build_base_sha="$(skopeo inspect "docker://${BUILD_REPO}:${TAG}-tiny" | jq .Digest -r)"
         build_cnb_sha="$(skopeo inspect "docker://${BUILD_REPO}:${TAG}-tiny-cnb" | jq .Digest -r)"
 
         echo "::set-output name=run_base_sha::${run_base_sha}"
@@ -74,7 +65,6 @@ jobs:
       uses: paketo-buildpacks/stacks/actions/release-notes@main
       with:
         build_base_image: "${{ env.BUILD_REPO }}@${{ steps.image-refs.outputs.build_base_sha }}"
-        build_base_image_tag: "${{ env.BUILD_REPO }}:${{ env.BUILD_BASE_IMAGE_TAG }}"
         build_cnb_image: "${{ env.BUILD_REPO }}@${{ steps.image-refs.outputs.build_cnb_sha }}"
         run_cnb_image: "${{ env.RUN_REPO }}@${{ steps.image-refs.outputs.run_cnb_sha }}"
         run_base_image: "${{ env.RUN_REPO }}@${{ steps.image-refs.outputs.run_base_sha }}"

--- a/.github/workflows/publish-stack-images.yml
+++ b/.github/workflows/publish-stack-images.yml
@@ -78,8 +78,6 @@ jobs:
         build_base_image="$(cat build-base-image)"
         run_base_image="$(cat run-base-image)"
 
-        echo "::set-output name=build_base_image_tag::$(cat build-base-image-tag)"
-
         published_build_base_image="$(echo "$build_base_image" | sed 's/build-rc@/build@/')"
         published_run_base_image="$(echo "$run_base_image" | sed 's/run-rc@/run@/')"
 
@@ -101,7 +99,6 @@ jobs:
         sudo skopeo copy "docker://paketobuildpacks/build:tiny-cnb" "docker://paketobuildpacks/build:${version}-tiny-cnb"
         sudo skopeo copy "docker://paketobuildpacks/build:tiny-cnb" "docker://paketobuildpacks/build:tiny-cnb"
 
-
         sudo skopeo copy "docker://${run_base_image}" "docker://paketobuildpacks/run:tiny"
         sudo skopeo copy "docker://${run_base_image}" "docker://paketobuildpacks/run:${version}-tiny"
 
@@ -121,6 +118,9 @@ jobs:
         sudo skopeo copy "docker://${build_base_image}" "docker://cloudfoundry/build:tiny-cnb"
         sudo skopeo copy "docker://${build_base_image}" "docker://cloudfoundry/build:${version}-tiny-cnb"
 
+        sudo skopeo copy "docker://paketobuildpacks/build:tiny-cnb" "docker://cloudfoundry/build:tiny-cnb"
+        sudo skopeo copy "docker://paketobuildpacks/build:tiny-cnb" "docker://cloudfoundry/build:${version}-tiny-cnb"
+
         sudo skopeo copy "docker://${run_base_image}" "docker://cloudfoundry/run:tiny"
         sudo skopeo copy "docker://${run_base_image}" "docker://cloudfoundry/run:${version}-tiny"
 
@@ -135,6 +135,5 @@ jobs:
         event: receipt-update
         payload: |
           {
-            "tag": "${{ steps.publish.outputs.version }}",
-            "build_base_image_tag" : "${{ steps.publish.outputs.build_base_image_tag }}"
+            "tag": "${{ steps.publish.outputs.version }}"
           }


### PR DESCRIPTION
## Summary
* Build base image instead of using build image from base stack
* Depends on https://github.com/paketo-buildpacks/stacks/pull/47


## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
