### PR TITLE
Move stack RC images to paketotesting

### DIFF
--- a/.github/workflows/publish-stack-images.yml
+++ b/.github/workflows/publish-stack-images.yml
@@ -78,8 +78,8 @@ jobs:
         build_base_image="$(cat build-base-image)"
         run_base_image="$(cat run-base-image)"
 
-        published_build_base_image="$(echo "$build_base_image" | sed 's/build-rc@/build@/')"
-        published_run_base_image="$(echo "$run_base_image" | sed 's/run-rc@/run@/')"
+        published_build_base_image="$(echo "$build_base_image" | sed 's|paketotesting/build-rc@|paketobuildpacks/build@|')"
+        published_run_base_image="$(echo "$run_base_image" | sed 's|paketotesting/run-rc@|paketobuildpacks/run@|')"
 
         build_cnb_image="$(cat build-cnb-image)"
         run_cnb_image="$(cat run-cnb-image)"


### PR DESCRIPTION
## Summary
Move RC image to the `paketotesting` dockerhub user

Depends on https://github.com/paketo-buildpacks/stacks/pull/50

## Use Cases
Keeps non-production images out of `paketobuildpacks`

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [X] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
