### PR TITLE
Add tiny base image to publish workflow

### DIFF
--- a/.github/workflows/publish-stack-images.yml
+++ b/.github/workflows/publish-stack-images.yml
@@ -92,12 +92,11 @@ jobs:
           docker build -t "paketobuildpacks/run:tiny-cnb" \
           --label "io.buildpacks.stack.metadata={\"base-image\": \"${published_run_base_image}\"}" -
 
-        sudo skopeo copy "docker://${build_cnb_image}" "docker://paketobuildpacks/build:tiny-cnb"
-        sudo skopeo copy "docker://${build_cnb_image}" "docker://paketobuildpacks/build:$version-tiny-cnb"
+        sudo skopeo copy "docker://${build_base_image}" "docker://paketobuildpacks/build:tiny"
+        sudo skopeo copy "docker://${build_base_image}" "docker://paketobuildpacks/build:${version}-tiny"
 
         docker push "paketobuildpacks/build:tiny-cnb"
         sudo skopeo copy "docker://paketobuildpacks/build:tiny-cnb" "docker://paketobuildpacks/build:${version}-tiny-cnb"
-        sudo skopeo copy "docker://paketobuildpacks/build:tiny-cnb" "docker://paketobuildpacks/build:tiny-cnb"
 
         sudo skopeo copy "docker://${run_base_image}" "docker://paketobuildpacks/run:tiny"
         sudo skopeo copy "docker://${run_base_image}" "docker://paketobuildpacks/run:${version}-tiny"


### PR DESCRIPTION
## Summary
Now that we are publishing a tiny build base image, it needs to be added to the publish workflow

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
