### PR TITLE
Add a workflow step that will file an issue if the release fails

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -164,3 +164,19 @@ jobs:
         name: ${{ steps.get-version.outputs.version }}
         body: ${{ steps.create-release-notes.outputs.release_body }}
         draft: false
+
+    - name: File Issue
+      if: ${{ failure() }}
+      run: |
+        echo "${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}" | gh auth login --with-token
+        release_issue=$(gh issue list --json number --label release-issue --jq .[0].number)
+
+        if [ -z $release_issue ]; \
+        then gh issue create \
+        --title "Failure: create-release workflow" \
+        --label "release-issue" \
+        --body "[Create release workflow](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}) failed to run. Please take a look to ensure CVE patches can be released. (cc @paketo-buildpacks/stacks-maintainers)" \
+        -R ${{github.repository}}; \
+        else gh issue comment $release_issue --body "Another failure occurred: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}"; \
+        fi
+        echo $release_issue


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

Recently it came to our attention that no stack releases had come out in days due to our release automation failing. This PR adds a workflow step to file an issue on the repository  notifying us of a failed release job.

If an issue already exists, it'll be updated to include a comment with the newest failure. I have fully tested this workflow step out on a forked repository.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [X] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
